### PR TITLE
Excludes Novels from AniList search

### DIFF
--- a/src/components/SearchModal.vue
+++ b/src/components/SearchModal.vue
@@ -60,7 +60,7 @@ async function search () {
   const graphqlQuery = `
     query ($search: String) {
       Page(page: 1, perPage: 10) {
-        media(search: $search, type: MANGA) {
+        media(search: $search, type: MANGA, format_not: NOVEL) {
           id
           title { romaji }
           status


### PR DESCRIPTION
As Tachiyomi is mainly focused on Manga and don't support Novels directly

Feel free to reject if you still want to include Novels in search